### PR TITLE
Fix backports in Debian Stretch (empty backports hash)`

### DIFF
--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -13,6 +13,7 @@ inherits monit::params {
         # Monit is not available in the standard repositories
         include ::epel
     } elsif $::lsbdistcodename == 'buster' and $manage_backports {
+        include ::apt
         include ::apt::backports
     }
 }


### PR DESCRIPTION
Signed-off-by: Kibahop <petri.lammi@puppeteers.net>

This fixes:

Evaluation Error: Operator '[]' is not applicable to an Undef Value 

in Debian Buster.